### PR TITLE
fix(release): sync lockfile for v1.1.6 publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@eslint/js": "^9.39.3",
         "@types/node": "^25.3.0",
         "eslint": "^9.39.3",
-        "globals": "^16.5.0",
+        "globals": "^17.3.0",
         "jiti": "^2.6.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1"
@@ -853,7 +853,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- sync `package-lock.json` with `package.json` on main for globals 17.3.0
- recover v1.1.6 publish path using legacy tag format

## Linked issue
Closes #11

## Scope
- [x] frouter CLI
- [ ] site
- [ ] both

## SemVer impact
- [x] patch
- [ ] minor
- [ ] major (breaking change)

## Branch flow check
- [ ] This PR targets `dev` from a feature/fix/chore/docs/refactor/test/ci branch.
- [x] This PR targets `main` from `release/*` or `hotfix/*`.

## Verification
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`
